### PR TITLE
Use a logarithmic bucketing histogram & slow tick counter

### DIFF
--- a/histogram.cc
+++ b/histogram.cc
@@ -2,17 +2,15 @@
 #include "histogram.h"
 
 #include <vector>
+#include <cmath>
 
-BucketingHistogram::BucketingHistogram(double min, double max, double step)
-  : bucket_min_(min)
-  , bucket_max_(max)
-  , bucket_step_(step)
-  , sample_sum_(0.0)
+LogarithmicBucketingHistogram::LogarithmicBucketingHistogram(int num_buckets)
+  : sample_sum_(0.0)
   , sample_count_(0)
-  , vector_(std::ceil((max - min) / step) + 2) {
+  , vector_(num_buckets + 1) {
 }
 
-void BucketingHistogram::Reset() {
+void LogarithmicBucketingHistogram::Reset() {
   sample_count_ = 0;
   sample_sum_ = 0.0;
   sample_min_ = 0.0;
@@ -21,15 +19,11 @@ void BucketingHistogram::Reset() {
   std::fill(vector_.begin(), vector_.end(), std::make_pair(0.0, 0));
 }
 
-void BucketingHistogram::Sample(double value) {
-  size_t bucket;
+void LogarithmicBucketingHistogram::Sample(double value) {
+  size_t bucket = log2(value);
 
-  if (value > bucket_max_) {
-    bucket = vector_.size() - 2;
-  } else if (value < bucket_min_) {
+  if (bucket >= vector_.size()) {
     bucket = vector_.size() - 1;
-  } else {
-    bucket = (size_t)((value - bucket_min_) / bucket_step_);
   }
 
   sample_sum_ += value;
@@ -47,7 +41,7 @@ void BucketingHistogram::Sample(double value) {
   vector_[bucket].second++;
 }
 
-double BucketingHistogram::GetApproximatePercentile(size_t percentile) {
+double LogarithmicBucketingHistogram::GetApproximatePercentile(size_t percentile) {
   size_t necessary_samples = std::ceil(percentile / 100.0 * sample_count_);
   size_t samples = 0;
 

--- a/histogram.h
+++ b/histogram.h
@@ -5,12 +5,8 @@
 #include <cmath>
 #include <vector>
 
-class BucketingHistogram {
+class LogarithmicBucketingHistogram {
 private:
-  const double bucket_min_;
-  const double bucket_max_;
-  const double bucket_step_;
-
   double sample_min_;
   double sample_max_;
   double sample_sum_;
@@ -21,7 +17,7 @@ private:
 public:
   /**
    */
-  BucketingHistogram(double min, double max, double step);
+  LogarithmicBucketingHistogram(int num_buckets);
 
   /**
    */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeswim-uvmon",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "Nathan Lawrence <ch@osga.me>",
   "main": "index.js",
   "repository": "https://github.com/chaosgame/edgeswim-uvmon",


### PR DESCRIPTION
Hello @dudeche, @sboora, @traviscrawford, 

Please review the following commits I made in branch 'nathan-uvmon2'.

c88dff5b66f5a32b77c520999b3c0493f3e3c214 (2015-09-29 14:43:09 -0700)
Use a logarithmic bucketing histogram & slow tick counter

Right now, our histogram implementation buckets at 10ms.  Our outliers (max) are
showing up as >300ms while there isn't enough resolution at the low end to
distinguish between the 95th percentile and the 99th percentile.

Also add a slow tick counter -- since we're trying to eliminate ticks > 100ms, we
should be counting how many of there there are.

R=@dudeche
R=@sboora
R=@traviscrawford

Test plan: 'not tested'
