### PR TITLE
Fix a subtle memory leak

### DIFF
--- a/profiler_wrapper.cc
+++ b/profiler_wrapper.cc
@@ -131,9 +131,9 @@ void CpuProfilerWrapper::LogFilteredProfile(
   uv_fs_t *write_req = new uv_fs_t;
   std::string stack = s.str();
 
-  char *buf = new char[stack.size()];
-  std::memcpy(buf, stack.data(), stack.size());
-  uv_buf_t uvbuf = uv_buf_init(buf, stack.size());
+  write_req->data = new char[stack.size()];
+  std::memcpy(write_req->data, stack.data(), stack.size());
+  uv_buf_t uvbuf = uv_buf_init(static_cast<char*>(write_req->data), stack.size());
 
   uv_fs_write(
     uv_default_loop(),
@@ -146,8 +146,9 @@ void CpuProfilerWrapper::LogFilteredProfile(
 }
 
 void CpuProfilerWrapper::LogWrittenCallback(uv_fs_t *write_req) {
-  if (write_req->bufs) delete[] write_req->bufs[0].base;
   uv_fs_req_cleanup(write_req);
+
+  delete static_cast<char*>(write_req->data);
   delete write_req;
 }
 


### PR DESCRIPTION
Hello @dudeche, @sboora, 

Please review the following commits I made in branch 'nathan-libuv'.

b9dd0f33947ad8368f114b4f1d73494760f3924b (2015-10-07 15:49:00 -0700)
Fix a subtle memory leak
It appears that libuv now frees the write_req->bufs struct upon a successful write.

This means that the call to `delete[] write_req->bufs[0].base;` will no longer work
because `write_req->bufs` is NULL.  The new check for `if (write_req->bufs)` added
in a previous pull request fixed the immediate segfault, but introduced
the memory leak.

To fix the issue, we now also pass along the pointer to `buf->data` in the
`write_req->data` field.

R=@dudeche
R=@sboora

Test plan: 'Unit tests.'
